### PR TITLE
Update hpe cinder volume driver to slable/pike

### DIFF
--- a/cinder/tests/unit/volume/drivers/hpe/test_hpe3par.py
+++ b/cinder/tests/unit/volume/drivers/hpe/test_hpe3par.py
@@ -7574,6 +7574,70 @@ class TestHPE3PARISCSIDriver(HPE3PARBaseDriver, test.TestCase):
             self.assertEqual('test-user', auth_username)
             self.assertEqual('test-pass', auth_password)
 
+    def test_create_host_chap_enabled_and_host_with_chap_cred(self):
+        # setup_mock_client drive with CHAP enabled configuration
+        # and return the mock HTTP 3PAR client
+        config = self.setup_configuration()
+        config.hpe3par_iscsi_chap_enabled = True
+        mock_client = self.setup_driver(config=config)
+
+        mock_client.getVolume.return_value = {'userCPG': HPE3PAR_CPG}
+        mock_client.getCPG.return_value = {}
+        mock_client.getHost.return_value = {
+            'name': self.FAKE_HOST,
+            'initiatorChapEnabled': True,
+            'iSCSIPaths': [{
+                "name": "iqn.1993-08.org.debian:01:222"
+            }]
+        }
+        mock_client.queryHost.return_value = None
+        mock_client.getVLUN.return_value = {'lun': self.TARGET_LUN}
+
+        expected_mod_request = {
+            'chapOperation': mock_client.HOST_EDIT_ADD,
+            'chapOperationMode': mock_client.CHAP_INITIATOR,
+            'chapName': 'test-user',
+            'chapSecret': 'test-pass'
+        }
+
+        def get_side_effect(*args):
+            data = {'value': None}
+            if args[1] == CHAP_USER_KEY:
+                data['value'] = 'test-user'
+            elif args[1] == CHAP_PASS_KEY:
+                data['value'] = 'test-pass'
+            return data
+
+        mock_client.getVolumeMetaData.side_effect = get_side_effect
+
+        with mock.patch.object(hpecommon.HPE3PARCommon,
+                               '_create_client') as mock_create_client:
+            mock_create_client.return_value = mock_client
+            common = self.driver._login()
+            host, auth_username, auth_password = self.driver._create_host(
+                common, self.volume, self.connector)
+
+            expected = [
+                mock.call.getVolume('osv-0DM4qZEVSKON-DXN-NwVpw'),
+                mock.call.getCPG(HPE3PAR_CPG),
+                mock.call.getVolumeMetaData(
+                    'osv-0DM4qZEVSKON-DXN-NwVpw', CHAP_USER_KEY),
+                mock.call.getVolumeMetaData(
+                    'osv-0DM4qZEVSKON-DXN-NwVpw', CHAP_PASS_KEY),
+                mock.call.getHost(self.FAKE_HOST),
+                mock.call.queryHost(iqns=['iqn.1993-08.org.debian:01:222']),
+                mock.call.modifyHost(
+                    'fakehost',
+                    expected_mod_request),
+                mock.call.getHost(self.FAKE_HOST)
+            ]
+
+            mock_client.assert_has_calls(expected)
+
+            self.assertEqual(self.FAKE_HOST, host['name'])
+            self.assertEqual('test-user', auth_username)
+            self.assertEqual('test-pass', auth_password)
+
     def test_create_host_chap_enabled_and_host_without_chap_cred(self):
         # setup_mock_client driver
         # and return the mock HTTP 3PAR client

--- a/cinder/tests/unit/volume/drivers/hpe/test_hpelefthand.py
+++ b/cinder/tests/unit/volume/drivers/hpe/test_hpelefthand.py
@@ -571,6 +571,32 @@ class TestHPELeftHandISCSIDriver(HPELeftHandBaseDriver, test.TestCase):
                 exception.VolumeBackendAPIException,
                 self.driver.initialize_connection, self.volume, self.connector)
 
+    def test_create_server(self):
+        # setup driver with default configuration
+        # and return the mock HTTP LeftHand client
+        mock_client = self.setup_driver()
+
+        # mock return value of getVolumeByName
+        mock_client.getServerByName.side_effect = hpeexceptions.HTTPNotFound()
+        mock_client.createServer.return_value = {'id': self.server_id}
+
+        with mock.patch.object(hpe_lefthand_iscsi.HPELeftHandISCSIDriver,
+                               '_create_client') as mock_do_setup:
+            mock_do_setup.return_value = mock_client
+
+            # create server
+            self.driver._create_server(self.connector, mock_client)
+
+            expected = [
+                mock.call.getServerByName('fakehost'),
+                mock.call.createServer(
+                    'fakehost',
+                    'iqn.1993-08.org.debian:01:222',
+                    None)]
+
+            # validate call chain
+            mock_client.assert_has_calls(expected)
+
     def test_initialize_connection_session_exists(self):
 
         # setup driver with default configuration

--- a/cinder/volume/drivers/hpe/hpe_3par_fc.py
+++ b/cinder/volume/drivers/hpe/hpe_3par_fc.py
@@ -114,10 +114,11 @@ class HPE3PARFCDriver(driver.ManageableVD,
         3.0.13 - Create one vlun in single path configuration. bug #1727176
         3.0.14 - Added check to remove FC zones. bug #1730720
         3.0.15 - Create FC vlun as host sees. bug #1734505
+        3.0.16 - Handle force detach case. bug #1686745
 
     """
 
-    VERSION = "3.0.15"
+    VERSION = "3.0.16"
 
     # The name of the CI wiki page.
     CI_WIKI_NAME = "HPE_Storage_CI"
@@ -331,28 +332,34 @@ class HPE3PARFCDriver(driver.ManageableVD,
         """Driver entry point to unattach a volume from an instance."""
         common = self._login()
         try:
-            hostname = common._safe_hostname(connector['host'])
-            common.terminate_connection(volume, hostname,
-                                        wwn=connector['wwpns'])
+            is_force_detach = connector is None
+            if is_force_detach:
+                common.terminate_connection(volume, None, None)
+                # TODO(sonivi): remove zones, if not required
+                # for now, do not remove zones
+                zone_remove = False
+            else:
+                hostname = common._safe_hostname(connector['host'])
+                common.terminate_connection(volume, hostname,
+                                            wwn=connector['wwpns'])
+
+                zone_remove = True
+                try:
+                    vluns = common.client.getHostVLUNs(hostname)
+                except hpeexceptions.HTTPNotFound:
+                    # No more exports for this host.
+                    pass
+                else:
+                    # Vlun exists, so check for wwpn entry.
+                    for wwpn in connector.get('wwpns'):
+                        for vlun in vluns:
+                            if (vlun.get('active') and
+                                    vlun.get('remoteName') == wwpn.upper()):
+                                zone_remove = False
+                                break
 
             info = {'driver_volume_type': 'fibre_channel',
                     'data': {}}
-
-            zone_remove = True
-
-            try:
-                vluns = common.client.getHostVLUNs(hostname)
-            except hpeexceptions.HTTPNotFound:
-                # No more exports for this host.
-                pass
-            else:
-                # Vlun exists, so check for wwpn entry.
-                for wwpn in connector.get('wwpns'):
-                    for vlun in vluns:
-                        if vlun.get('active') and \
-                           vlun.get('remoteName') == wwpn.upper():
-                            zone_remove = False
-                            break
 
             if zone_remove:
                 LOG.info("Need to remove FC Zone, building initiator "


### PR DESCRIPTION
This is a backport from upstream openstack/cinder repository, containing last 3 commits from stable/pike label. 
Repo starlingx-staging/stx-cinder is based on pike version as well, but it is missing these last 3 commits from upstream. These commits are fixing a number of issues affecting user experience (most important of which is live migration support). 

Storyboard:  https://storyboard.openstack.org/#!/story/2002996
Task Id: 26201