### PR TITLE
Enable parallel cinder backups

### DIFF
--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -347,7 +347,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
                 container, object_name, extra_metadata=extra_metadata
         ) as writer:
             writer.write(output_data)
-        md5 = hashlib.md5(data).hexdigest()
+        md5 = eventlet.tpool.execute(hashlib.md5, data).hexdigest()
         obj[object_name]['md5'] = md5
         LOG.debug('backup MD5 for %(object_name)s: %(md5)s',
                   {'object_name': object_name, 'md5': md5})
@@ -439,6 +439,25 @@ class ChunkedBackupDriver(driver.BackupDriver):
                                                extra_usage_info=
                                                object_meta)
 
+    def _calculate_sha(self, data):
+        """Calculate SHA256 of a data chunk.
+
+        This method cannot log anything as it is called on a native thread.
+        """
+        # NOTE(geguileo): Using memoryview to avoid data copying when slicing
+        # for the sha256 call.
+        chunk = memoryview(data)
+        shalist = []
+        off = 0
+        datalen = len(chunk)
+        while off < datalen:
+            chunk_end = min(datalen, off + self.sha_block_size_bytes)
+            block = chunk[off:chunk_end]
+            sha = hashlib.sha256(block).hexdigest()
+            shalist.append(sha)
+            off += self.sha_block_size_bytes
+        return shalist
+
     def backup(self, backup, volume_file, backup_metadata=True):
         """Backup the given volume.
 
@@ -517,18 +536,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
                 break
 
             # Calculate new shas with the datablock.
-            shalist = []
-            off = 0
-            datalen = len(data)
-            while off < datalen:
-                chunk_start = off
-                chunk_end = chunk_start + self.sha_block_size_bytes
-                if chunk_end > datalen:
-                    chunk_end = datalen
-                chunk = data[chunk_start:chunk_end]
-                sha = hashlib.sha256(chunk).hexdigest()
-                shalist.append(sha)
-                off += self.sha_block_size_bytes
+            shalist = eventlet.tpool.execute(self._calculate_sha, data)
             sha256_list.extend(shalist)
 
             # If parent_backup is not None, that means an incremental
@@ -555,7 +563,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
 
                 # The last extent extends to the end of data buffer.
                 if extent_off != -1:
-                    extent_end = datalen
+                    extent_end = len(data)
                     segment = data[extent_off:extent_end]
                     self._backup_chunk(backup, container, segment,
                                        data_offset + extent_off,

--- a/cinder/backup/chunkeddriver.py
+++ b/cinder/backup/chunkeddriver.py
@@ -76,12 +76,18 @@ class ChunkedBackupDriver(driver.BackupDriver):
         try:
             if algorithm.lower() in ('none', 'off', 'no'):
                 return None
-            elif algorithm.lower() in ('zlib', 'gzip'):
+            if algorithm.lower() in ('zlib', 'gzip'):
                 import zlib as compressor
-                return compressor
+                result = compressor
             elif algorithm.lower() in ('bz2', 'bzip2'):
                 import bz2 as compressor
-                return compressor
+                result = compressor
+            else:
+                result = None
+            if result:
+                # NOTE(geguileo): Compression/Decompression starves
+                # greenthreads so we use a native thread instead.
+                return eventlet.tpool.Proxy(result)
         except ImportError:
             pass
 
@@ -104,6 +110,16 @@ class ChunkedBackupDriver(driver.BackupDriver):
         self.compressor = \
             self._get_compressor(CONF.backup_compression_algorithm)
         self.support_force_delete = True
+
+    def _get_object_writer(self, container, object_name, extra_metadata=None):
+        """Return writer proxy-wrapped to execute methods in native thread."""
+        writer = self.get_object_writer(container, object_name, extra_metadata)
+        return eventlet.tpool.Proxy(writer)
+
+    def _get_object_reader(self, container, object_name, extra_metadata=None):
+        """Return reader proxy-wrapped to execute methods in native thread."""
+        reader = self.get_object_reader(container, object_name, extra_metadata)
+        return eventlet.tpool.Proxy(reader)
 
     # To create your own "chunked" backup driver, implement the following
     # abstract methods.
@@ -222,7 +238,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
         metadata_json = json.dumps(metadata, sort_keys=True, indent=2)
         if six.PY3:
             metadata_json = metadata_json.encode('utf-8')
-        with self.get_object_writer(container, filename) as writer:
+        with self._get_object_writer(container, filename) as writer:
             writer.write(metadata_json)
         LOG.debug('_write_metadata finished. Metadata: %s.', metadata_json)
 
@@ -243,7 +259,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
         sha256file_json = json.dumps(sha256file, sort_keys=True, indent=2)
         if six.PY3:
             sha256file_json = sha256file_json.encode('utf-8')
-        with self.get_object_writer(container, filename) as writer:
+        with self._get_object_writer(container, filename) as writer:
             writer.write(sha256file_json)
         LOG.debug('_write_sha256file finished.')
 
@@ -253,7 +269,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
         LOG.debug('_read_metadata started, container name: %(container)s, '
                   'metadata filename: %(filename)s.',
                   {'container': container, 'filename': filename})
-        with self.get_object_reader(container, filename) as reader:
+        with self._get_object_reader(container, filename) as reader:
             metadata_json = reader.read()
         if six.PY3:
             metadata_json = metadata_json.decode('utf-8')
@@ -267,7 +283,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
         LOG.debug('_read_sha256file started, container name: %(container)s, '
                   'sha256 filename: %(filename)s.',
                   {'container': container, 'filename': filename})
-        with self.get_object_reader(container, filename) as reader:
+        with self._get_object_reader(container, filename) as reader:
             sha256file_json = reader.read()
         if six.PY3:
             sha256file_json = sha256file_json.decode('utf-8')
@@ -327,7 +343,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
         algorithm, output_data = self._prepare_output_data(data)
         obj[object_name]['compression'] = algorithm
         LOG.debug('About to put_object')
-        with self.get_object_writer(
+        with self._get_object_writer(
                 container, object_name, extra_metadata=extra_metadata
         ) as writer:
             writer.write(output_data)
@@ -349,8 +365,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
         data_size_bytes = len(data)
         # Execute compression in native thread so it doesn't prevent
         # cooperative greenthread switching.
-        compressed_data = eventlet.tpool.execute(self.compressor.compress,
-                                                 data)
+        compressed_data = self.compressor.compress(data)
         comp_size_bytes = len(compressed_data)
         algorithm = CONF.backup_compression_algorithm.lower()
         if comp_size_bytes >= data_size_bytes:
@@ -618,7 +633,7 @@ class ChunkedBackupDriver(driver.BackupDriver):
                           'volume_id': volume_id,
                       })
 
-            with self.get_object_reader(
+            with self._get_object_reader(
                     container, object_name,
                     extra_metadata=extra_metadata) as reader:
                 body = reader.read()

--- a/cinder/backup/driver.py
+++ b/cinder/backup/driver.py
@@ -364,12 +364,24 @@ class BackupDriver(base.Base):
 
     @abc.abstractmethod
     def backup(self, backup, volume_file, backup_metadata=False):
-        """Start a backup of a specified volume."""
+        """Start a backup of a specified volume.
+
+        Some I/O operations may block greenthreads, so in order to prevent
+        starvation parameter volume_file will be a proxy that will execute all
+        methods in native threads, so the method implementation doesn't need to
+        worry about that..
+        """
         return
 
     @abc.abstractmethod
     def restore(self, backup, volume_id, volume_file):
-        """Restore a saved backup."""
+        """Restore a saved backup.
+
+        Some I/O operations may block greenthreads, so in order to prevent
+        starvation parameter volume_file will be a proxy that will execute all
+        methods in native threads, so the method implementation doesn't need to
+        worry about that..
+        """
         return
 
     @abc.abstractmethod

--- a/cinder/tests/unit/backup/drivers/test_backup_swift.py
+++ b/cinder/tests/unit/backup/drivers/test_backup_swift.py
@@ -27,6 +27,7 @@ import tempfile
 import threading
 import zlib
 
+from eventlet import tpool
 import mock
 from oslo_config import cfg
 from swiftclient import client as swift
@@ -821,8 +822,10 @@ class BackupSwiftTestCase(test.TestCase):
         self.assertIsNone(compressor)
         compressor = service._get_compressor('zlib')
         self.assertEqual(zlib, compressor)
+        self.assertIsInstance(compressor, tpool.Proxy)
         compressor = service._get_compressor('bz2')
         self.assertEqual(bz2, compressor)
+        self.assertIsInstance(compressor, tpool.Proxy)
         self.assertRaises(ValueError, service._get_compressor, 'fake')
 
     def test_prepare_output_data_effective_compression(self):
@@ -831,17 +834,17 @@ class BackupSwiftTestCase(test.TestCase):
         thread_dict = {}
         original_compress = zlib.compress
 
-        def my_compress(data, *args, **kwargs):
+        def my_compress(data):
             thread_dict['compress'] = threading.current_thread()
             return original_compress(data)
+
+        self.mock_object(zlib, 'compress', side_effect=my_compress)
 
         service = swift_dr.SwiftBackupDriver(self.ctxt)
         # Set up buffer of 128 zeroed bytes
         fake_data = b'\0' * 128
 
-        with mock.patch.object(service.compressor, 'compress',
-                               side_effect=my_compress):
-            result = service._prepare_output_data(fake_data)
+        result = service._prepare_output_data(fake_data)
 
         self.assertEqual('zlib', result[0])
         self.assertGreater(len(fake_data), len(result[1]))


### PR DESCRIPTION
Backporting of commits needed to enable parallel cinder backups on stx-cinder

StoryBoard: Story 2003115 Task 26476
https://storyboard.openstack.org/#!/story/2003115

Testing:
Tox py27 and pep8
Code compiled and run on a hardware lab
