### PR TITLE
py3 - foundation - Get UT run in py36

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=${OS_TEST_PATH:-./cinder/tests/unit}
+top_dir=./

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,8 +1,0 @@
-[DEFAULT]
-test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
-             OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
-             OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
-             ${PYTHON:-python} -m subunit.run discover -t ./ ${OS_TEST_PATH:-./cinder/tests/unit}  $LISTOPT $IDOPTION
-
-test_id_option=--load-list $IDFILE
-test_list_option=--list

--- a/cinder/tests/unit/test_exception.py
+++ b/cinder/tests/unit/test_exception.py
@@ -15,27 +15,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from cinder import exception
-from cinder import test
-
 import mock
 import six
 from six.moves import http_client
 import webob.util
 
-
-class ExceptionTestCase(test.TestCase):
-    @staticmethod
-    def _raise_exc(exc):
-        raise exc()
-
-    def test_exceptions_raise(self):
-        # NOTE(dprince): disable format errors since we are not passing kwargs
-        self.flags(fatal_exception_format_errors=False)
-        for name in dir(exception):
-            exc = getattr(exception, name)
-            if isinstance(exc, type):
-                self.assertRaises(exc, self._raise_exc, exc)
+from cinder import exception
+from cinder import test
 
 
 class CinderExceptionTestCase(test.TestCase):

--- a/cinder/tests/unit/test_image_utils.py
+++ b/cinder/tests/unit/test_image_utils.py
@@ -1508,6 +1508,10 @@ class TestVhdUtils(test.TestCase):
     @mock.patch('cinder.image.image_utils.utils.execute')
     def test_coalesce_chain(self, mock_exec, mock_size, mock_resize,
                             mock_coal, mock_temp):
+
+        # os.path.join does not work with MagicMock objects in py36.
+        mock_temp.return_value.__enter__.return_value = 'fake_temp_dir'
+
         vhd_chain = (mock.sentinel.first,
                      mock.sentinel.second,
                      mock.sentinel.third,

--- a/cinder/tests/unit/volume/drivers/dell_emc/vmax/test_vmax.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/vmax/test_vmax.py
@@ -4798,6 +4798,8 @@ class VMAXMaskingTest(test.TestCase):
         configuration.config_group = 'MaskingTests'
         self._gather_info = common.VMAXCommon._gather_info
         common.VMAXCommon._gather_info = mock.Mock()
+        rest.VMAXRest._establish_rest_session = mock.Mock(
+            return_value=FakeRequestsSession())
         driver = common.VMAXCommon(
             'iSCSI', common.VMAXCommon.VERSION, configuration=configuration)
         driver_fc = common.VMAXCommon(

--- a/cinder/tests/unit/volume/drivers/test_gpfs.py
+++ b/cinder/tests/unit/volume/drivers/test_gpfs.py
@@ -2303,6 +2303,7 @@ class GPFSNFSDriverTestCase(test.TestCase):
                            mock_volume_path,
                            mock_local_path,
                            mock_delete_gpfs_file):
+        mock_local_path.return_value = '/tmp/abc123'
         self.driver.delete_volume('')
 
     @mock.patch('cinder.volume.drivers.ibm.gpfs.GPFSDriver.'

--- a/cinder/tests/unit/volume/drivers/test_nfs.py
+++ b/cinder/tests/unit/volume/drivers/test_nfs.py
@@ -691,9 +691,8 @@ class NfsDriverTestCase(test.TestCase):
     def test_create_sparsed_volume(self):
         self._set_driver()
         drv = self._driver
+        self.configuration.nfs_sparsed_volumes = True
         volume = self._simple_volume()
-
-        self.override_config('nfs_sparsed_volumes', True)
 
         with mock.patch.object(
                 drv, '_create_sparsed_file') as mock_create_sparsed_file:
@@ -710,8 +709,6 @@ class NfsDriverTestCase(test.TestCase):
         drv = self._driver
         self.configuration.nfs_sparsed_volumes = False
         volume = self._simple_volume()
-
-        self.override_config('nfs_sparsed_volumes', False)
 
         with mock.patch.object(
                 drv, '_create_regular_file') as mock_create_regular_file:

--- a/cinder/tests/unit/volume/drivers/test_qnap.py
+++ b/cinder/tests/unit/volume/drivers/test_qnap.py
@@ -26,6 +26,7 @@ import six
 from six.moves import urllib
 
 from cinder import test
+from cinder import utils
 from cinder.volume.drivers import qnap
 
 CONF = cfg.CONF
@@ -316,6 +317,14 @@ class QnapDriverBaseTestCase(test.TestCase):
         self.driver = None
         self.mock_HTTPConnection = None
         self.mock_object(qnap.QnapISCSIDriver, 'TIME_INTERVAL', 0)
+
+    @staticmethod
+    def sanitize(params):
+        sanitized = {_key: six.text_type(_value)
+                     for _key, _value in six.iteritems(params)
+                     if _value is not None}
+        sanitized = utils.create_ordereddict(sanitized)
+        return urllib.parse.urlencode(sanitized)
 
     @staticmethod
     def driver_mock_decorator(configuration):
@@ -1206,15 +1215,10 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['LUNCapacity'] = 100
         fake_params['lv_threshold'] = '80'
         fake_params['sid'] = 'fakeSid'
-        sanitized_params = {}
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
 
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         create_lun_url = (
-            '/cgi-bin/disk/iscsi_lun_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_lun_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1253,16 +1257,10 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['ha_sync'] = '1'
         fake_params['LUNIndex'] = 'fakeLunIndex'
         fake_params['sid'] = 'fakeSid'
-        sanitized_params = {}
 
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         delete_lun_url = (
-            '/cgi-bin/disk/iscsi_lun_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_lun_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1302,15 +1300,9 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['Pool_Info'] = '1'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         get_specific_poolinfo_url = (
-            '/cgi-bin/disk/disk_manage.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/disk_manage.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1352,16 +1344,9 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['controller_name'] = 'sca'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         create_target_url = (
-            '/cgi-bin/disk/iscsi_target_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_target_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1409,16 +1394,9 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['ha_sync'] = '1'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         add_target_init_url = (
-            '/cgi-bin/disk/iscsi_target_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_target_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1458,16 +1436,9 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['targetIndex'] = 'fakeTargetIndex'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         map_lun_url = (
-            '/cgi-bin/disk/iscsi_target_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_target_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1507,15 +1478,9 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['targetIndex'] = 'fakeTargetIndex'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         unmap_lun_url = (
-            '/cgi-bin/disk/iscsi_target_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_target_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1553,15 +1518,9 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['iSCSI_portal'] = '1'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         get_iscsi_portal_info_url = (
-            '/cgi-bin/disk/iscsi_portal_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_portal_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1598,16 +1557,10 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['func'] = 'extra_get'
         fake_params['lunList'] = '1'
         fake_params['sid'] = 'fakeSid'
-        sanitized_params = {}
 
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
-
+        fake_post_params = self.sanitize(fake_params)
         get_lun_info_url = (
-            '/cgi-bin/disk/iscsi_portal_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_portal_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1648,16 +1601,10 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['snap_start'] = '0'
         fake_params['snap_count'] = '100'
         fake_params['sid'] = 'fakeSid'
-        sanitized_params = {}
 
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         get_snapshot_info_url = (
-            '/cgi-bin/disk/snapshot.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/snapshot.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1699,16 +1646,10 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['vital'] = '1'
         fake_params['snapshot_type'] = '0'
         fake_params['sid'] = 'fakeSid'
-        sanitized_params = {}
 
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         create_snapshot_api_url = (
-            '/cgi-bin/disk/snapshot.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/snapshot.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1745,16 +1686,10 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['func'] = 'del_snapshots'
         fake_params['snapshotID'] = 'fakeSnapshotId'
         fake_params['sid'] = 'fakeSid'
-        sanitized_params = {}
 
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         api_delete_snapshot_url = (
-            '/cgi-bin/disk/snapshot.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/snapshot.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1794,16 +1729,10 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['snapshotID'] = 'fakeSnapshotId'
         fake_params['new_name'] = 'fakeLunName'
         fake_params['sid'] = 'fakeSid'
-        sanitized_params = {}
 
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         clone_snapshot_url = (
-            '/cgi-bin/disk/snapshot.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/snapshot.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1852,16 +1781,9 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['LUNStatus'] = 'fakeLunStatus'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         edit_lun_url = (
-            '/cgi-bin/disk/iscsi_lun_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_lun_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1942,16 +1864,10 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params = {}
         fake_params['subfunc'] = 'net_setting'
         fake_params['sid'] = 'fakeSid'
-        sanitized_params = {}
 
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         get_ethernet_ip_url = (
-            '/cgi-bin/sys/sysRequest.cgi?%s' % sanitized_params)
+            '/cgi-bin/sys/sysRequest.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -1990,15 +1906,9 @@ class QnapAPIExecutorTestCase(QnapDriverBaseTestCase):
         fake_params['targetIndex'] = 'fakeTargetIndex'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         get_target_info_url = (
-            '/cgi-bin/disk/iscsi_portal_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_portal_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -2043,15 +1953,9 @@ class QnapAPIExecutorTsTestCase(QnapDriverBaseTestCase):
         fake_params['ha_sync'] = '1'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         remove_target_init_url = (
-            '/cgi-bin/disk/iscsi_target_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_target_setting.cgi?%s' % fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -2091,15 +1995,9 @@ class QnapAPIExecutorTsTestCase(QnapDriverBaseTestCase):
         fake_params['ha_sync'] = '1'
         fake_params['sid'] = 'fakeSid'
 
-        sanitized_params = {}
-        for key in fake_params:
-            value = fake_params[key]
-            if value is not None:
-                sanitized_params[key] = six.text_type(value)
-
-        sanitized_params = urllib.parse.urlencode(sanitized_params)
+        fake_post_params = self.sanitize(fake_params)
         get_target_info_url = (
-            '/cgi-bin/disk/iscsi_portal_setting.cgi?%s' % sanitized_params)
+            '/cgi-bin/disk/iscsi_portal_setting.cgi?' + fake_post_params)
 
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
@@ -2133,8 +2031,13 @@ class QnapAPIExecutorTsTestCase(QnapDriverBaseTestCase):
         self.driver.api_executor.get_ethernet_ip(
             type='data')
 
+        fake_params = {}
+        fake_params['sid'] = 'fakeSid'
+        fake_params['subfunc'] = 'net_setting'
+
+        fake_post_params = self.sanitize(fake_params)
         get_ethernet_ip_url = (
-            '/cgi-bin/sys/sysRequest.cgi?subfunc=net_setting&sid=fakeSid')
+            '/cgi-bin/sys/sysRequest.cgi?' + fake_post_params)
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
             mock.call('GET', get_basic_info_url),
@@ -2171,8 +2074,14 @@ class QnapAPIExecutorTesTestCase(QnapDriverBaseTestCase):
         self.driver.api_executor.get_ethernet_ip(
             type='data')
 
+        fake_params = {}
+        fake_params['sid'] = 'fakeSid'
+        fake_params['subfunc'] = 'net_setting'
+
+        fake_post_params = self.sanitize(fake_params)
         get_ethernet_ip_url = (
-            '/cgi-bin/sys/sysRequest.cgi?subfunc=net_setting&sid=fakeSid')
+            '/cgi-bin/sys/sysRequest.cgi?' + fake_post_params)
+
         expected_call_list = [
             mock.call('POST', login_url, global_sanitized_params, header),
             mock.call('GET', get_basic_info_url),

--- a/cinder/tests/unit/volume/drivers/test_vzstorage.py
+++ b/cinder/tests/unit/volume/drivers/test_vzstorage.py
@@ -56,10 +56,6 @@ class VZStorageTestCase(test.TestCase):
     def setUp(self):
         super(VZStorageTestCase, self).setUp()
 
-        self._remotefsclient = mock.patch.object(
-            remotefs, 'VZStorageRemoteFSClient').start()
-        get_mount_point = mock.Mock(return_value=self._FAKE_MNT_POINT)
-        self._remotefsclient.get_mount_point = get_mount_point
         cfg = copy.copy(self._FAKE_VZ_CONFIG)
         self._vz_driver = vzstorage.VZStorageDriver(configuration=cfg)
         self._vz_driver._local_volume_dir = mock.Mock(
@@ -168,11 +164,28 @@ class VZStorageTestCase(test.TestCase):
         self.assertRaises(exception.VzStorageException,
                           self._vz_driver._ensure_share_mounted, ':')
 
-    def test_ensure_share_mounted(self):
+    @mock.patch.object(remotefs.RemoteFsClient, 'mount')
+    def test_ensure_share_mounted(self, mock_mount):
         drv = self._vz_driver
         share = self._FAKE_SHARE
-        drv.shares = {'1': '["1", "2", "3"]', share: '["some", "options"]'}
+        expected_calls = [
+            mock.call(
+                share,
+                ['-l', '/var/log/pstorage/cluster123-cinder.log.gz',
+                 '-u', 'cinder', '-g', 'root']),
+            mock.call(
+                share,
+                ['-l', '/var/log/pstorage/cluster123-cinder.log.gz'])
+        ]
+
+        share_flags = '["-u", "cinder", "-g", "root"]'
+        drv.shares[share] = share_flags
         drv._ensure_share_mounted(share)
+
+        drv.shares[share] = None
+        drv._ensure_share_mounted(share)
+
+        mock_mount.assert_has_calls(expected_calls)
 
     def test_find_share(self):
         drv = self._vz_driver

--- a/cinder/utils.py
+++ b/cinder/utils.py
@@ -19,12 +19,14 @@
 
 
 import abc
+from collections import OrderedDict
 import contextlib
 import datetime
 import functools
 import inspect
 import logging as py_logging
 import math
+import operator
 import os
 import pyclbr
 import random
@@ -1137,3 +1139,9 @@ def get_log_levels(prefix):
 
 def paths_normcase_equal(path_a, path_b):
     return os.path.normcase(path_a) == os.path.normcase(path_b)
+
+
+def create_ordereddict(adict):
+    """Given a dict, return a sorted OrderedDict."""
+    return OrderedDict(sorted(adict.items(),
+                              key=operator.itemgetter(0)))

--- a/cinder/volume/drivers/qnap.py
+++ b/cinder/volume/drivers/qnap.py
@@ -17,6 +17,7 @@ Volume driver for QNAP Storage.
 This driver supports QNAP Storage for iSCSI.
 """
 import base64
+from collections import OrderedDict
 import eventlet
 import functools
 import re
@@ -38,6 +39,7 @@ from six.moves import urllib
 from cinder import exception
 from cinder.i18n import _
 from cinder import interface
+from cinder import utils
 from cinder.volume import configuration
 from cinder.volume.drivers.san import san
 
@@ -886,12 +888,12 @@ class QnapAPIExecutor(object):
 
     def execute_login(self):
         """Login and return sid."""
-        params = {}
-        params['user'] = self.username
+        params = OrderedDict()
         params['pwd'] = base64.b64encode(self.password.encode("utf-8"))
         params['serviceKey'] = '1'
+        params['user'] = self.username
 
-        sanitized_params = {}
+        sanitized_params = OrderedDict()
 
         for key in params:
             value = params[key]
@@ -913,9 +915,12 @@ class QnapAPIExecutor(object):
         LOG.debug('sid: %s', self.sid)
 
     def _get_res_details(self, url, **kwargs):
-        sanitized_params = {}
+        sanitized_params = OrderedDict()
 
-        for key, value in kwargs.items():
+        # Sort the dict of parameters
+        params = utils.create_ordereddict(kwargs)
+
+        for key, value in params.items():
             LOG.debug('%(key)s = %(val)s',
                       {'key': key, 'val': value})
             if value is not None:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = py35,py27,compliance,pep8
+skip_missing_interpreters = true
+envlist = py36,py35,py27,compliance,pep8
 
 [testenv]
 # Note the hash seed is set to 0 until cinder can be tested with a
@@ -9,6 +10,10 @@ envlist = py35,py27,compliance,pep8
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
          PYTHONWARNINGS=default::DeprecationWarning
+         OS_STDOUT_CAPTURE=1
+         OS_STDERR_CAPTURE=1
+         OS_TEST_TIMEOUT=60
+         OS_TEST_PATH=./cinder/tests/unit
 usedevelop = True
 install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/pike} {opts} {packages}
 
@@ -19,8 +24,10 @@ deps = -r{toxinidir}/test-requirements.txt
 # the concurrency=<n> option.
 # call ie: 'tox -epy27 -- --concurrency=4'
 commands =
-  find . -type f -name "*.pyc" -delete
-  ostestr {posargs}
+  find . -ignore_readdir_race -type f -name "*.pyc" -delete
+  stestr run {posargs}
+  stestr slowest
+
 
 whitelist_externals =
   bash


### PR DESCRIPTION
1. Update tox.ini to support py36 which is the required version of to
run unit test in openstack stein.
https://governance.openstack.org/tc/goals/stein/python3-first.html

2. Backport the file test_exception.py which causing unit test abort
prematurely in py36. Upstream commit id:
402ded572da14b8f810fed32e35fa715a664cefb,
de59b02a388a96e06afcbc64c38650414bbed595

3. Fixed all the existing UT failures in py36.

After applying this patch, "tox -e py36", "tox -e py27", "tox -e pep8" can finish running successfully. This is the base for the subsequent patches that back porting to support py3.
