### PR TITLE
[py3-backport] ZFSSA volume driver REST client python3 fixes

### DIFF
--- a/cinder/volume/drivers/zfssa/restclient.py
+++ b/cinder/volume/drivers/zfssa/restclient.py
@@ -85,7 +85,7 @@ class RestResult(object):
             self.status = self.response.getcode()
             result = self.response.read()
             while result:
-                self.data += result
+                self.data += result.decode("utf-8")
                 result = self.response.read()
 
         if self.error:
@@ -104,7 +104,7 @@ class RestResult(object):
         if self.response is None:
             return None
         info = self.response.info()
-        return info.getheader(name)
+        return info.get(name)
 
 
 class RestClientError(Exception):
@@ -256,10 +256,11 @@ class RestClientURL(object):
 
         if body:
             if isinstance(body, dict):
-                body = str(json.dumps(body))
-
-        if body and len(body):
+                body = json.dumps(body)
+            body = body.encode("utf-8")
             out_hdrs['content-length'] = len(body)
+        else:
+            body = None
 
         zfssaurl = self._path(path, kwargs.get("base_path"))
         req = urllib.request.Request(zfssaurl, body, out_hdrs)


### PR DESCRIPTION
1) Although it's unlikely that non-ASCII characters would ever appear in
API requests, encode/decode("utf-8") handles bytes vs. strings.

2) In python2, HTTPMessage.getheader() was equivalent to
HTTPMessage.get(), but only the latter is available in python3.

cherry-pick from upstream repo for py3 support, commit id:
396086ad8f80f031453ef8985370964bd69c4560