### PR TITLE
[py3-backport] Make divisibility py3 compatible in DRBD driver

### DIFF
--- a/cinder/volume/drivers/drbdmanagedrv.py
+++ b/cinder/volume/drivers/drbdmanagedrv.py
@@ -278,10 +278,10 @@ class DrbdManageBaseDriver(driver.VolumeDriver):
 
     # DRBDmanage works in kiB units; Cinder uses GiB.
     def _vol_size_to_dm(self, size):
-        return int(size * units.Gi / units.Ki)
+        return int(size * units.Gi // units.Ki)
 
     def _vol_size_to_cinder(self, size):
-        return int(size * units.Ki / units.Gi)
+        return int(size * units.Ki // units.Gi)
 
     def is_clean_volume_name(self, name, prefix):
         try:


### PR DESCRIPTION
In python 2.x,
int / int = int
Eg: 3 / 2 = 1

But in python 3.x,
int / int = float (if the result turns out to be a
floating value)
Eg: 3 / 2 = 1.5

This patch addresses the change.

pick from upstream repo, commit:
972cff5a33bd459f77dd88e236d5100b7693d5f2